### PR TITLE
Added really long proxy timeout

### DIFF
--- a/dinghy.nginx.conf
+++ b/dinghy.nginx.conf
@@ -1,1 +1,3 @@
 client_max_body_size 4g;
+proxy_read_timeout 86400s;
+proxy_send_timeout 86400s;


### PR DESCRIPTION
When debugging in development, the default 60s timeout was causing issues.
