### PR TITLE
Fixed duplicated vhost block (removed unknown HTTPS_METHOD block)

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -147,14 +147,6 @@ server {
                 {{ end }}
 	}
 }
-{{ else if not (eq $https_method "nohttp") }}
-server {
-	server_name {{ .Host }};
-	listen 80;
-	access_log /var/log/nginx/access.log vhost;
- 	return 503 "Unknown HTTPS_METHOD {{ $https_method }}";
- 	add_header Content-Type text/plain;
- }
 {{ end }}
 {{ end }}
 


### PR DESCRIPTION
I think I've broken one thing in my previous PR. The "Unknown HTTPS_METHOD" block shows up for HTTPS_METHOD=redirect, breaking vhost (duplicated definition). I think it's best to just remove it, since it's not adding much anyway.
