### PR TITLE
doc update Chrome 58 SSL missing_subjectAltName

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ You can generate self-signed certificates using ```openssl```.
 ```bash
 openssl req -x509 -newkey rsa:2048 -keyout foo.bar.com.docker.key \
 -out foo.bar.com.docker.crt -days 365 -nodes \
--subj "/C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=foo.bar.com.docker"
+-subj "/C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=foo.bar.com.docker" \
+-config <(cat /etc/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName=DNS:foo.bar.com.docker")) \
+-reqexts SAN -extensions SAN
 ```
 
 To prevent your browser to emit warning regarding self-signed certificates, you can install them on your system as trusted certificates.


### PR DESCRIPTION
Chrome 58 appears to no longer support domain name in CN and now gives `missing_subjectAltName` (https://bugs.chromium.org/p/chromium/issues/detail?id=308330) with HSTS.