### PR TITLE
increase proxy_buffers and proxy_buffer_size

### DIFF
--- a/dinghy.nginx.conf
+++ b/dinghy.nginx.conf
@@ -3,3 +3,5 @@ client_header_buffer_size 256k;
 large_client_header_buffers 8 1024k;
 proxy_read_timeout 86400s;
 proxy_send_timeout 86400s;
+proxy_buffers 8 1024k;
+proxy_buffer_size 1024k;


### PR DESCRIPTION
This change will increase the size of proxy_buffers and proxy_buffer_size so that longer URLs don't return a 502 Bad Gateway.