### PR TITLE
Fix default `ssl_dhparam`

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -19,7 +19,7 @@ map $http_upgrade $proxy_connection {
 server_names_hash_bucket_size 128;
 
 # Default dhparam
-ssl_dhparam /etc/nginx/dhparam.pem;
+ssl_dhparam /etc/nginx/dhparam/dhparam.pem;
 
 gzip_types text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 


### PR DESCRIPTION
Hi, as mentioned by @paradite in #40, it seems like the default parameter specified by the jwilder/nginx-proxy is 

```
DHPARAM_FILE="/etc/nginx/dhparam/dhparam.pem"
```
https://github.com/jwilder/nginx-proxy/blob/02121df3b914061040df128e8266ccad81ce3046/generate-dhparam.sh#L9

We should have a additional `/dhparam` as a directory path. I could be missing something here with what is defined as "default" in this case, please let me know otherwise!