### PR TITLE
Redirect HTTPS requests for unknown subdomains to the index.html page

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -43,12 +43,44 @@ proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
 {{ end }}
 
+{{ $is_default_server_https := (and (exists (printf "/etc/nginx/certs/%s.crt" $TLD)) (exists (printf "/etc/nginx/certs/%s.key" $TLD))) }}
+
+{{ if $is_default_server_https }}
+
+server {
+  listen 80 default_server;
+  server_name _;
+  return 301 https://$host$request_uri;
+}
+
+server {
+	server_name _;
+	listen 443 http2 ssl;
+
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+	ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA;
+
+	ssl_prefer_server_ciphers on;
+	ssl_session_timeout 5m;
+	ssl_session_cache shared:SSL:50m;
+
+	ssl_certificate /etc/nginx/certs/{{ (printf "%s.crt" $TLD) }};
+	ssl_certificate_key /etc/nginx/certs/{{ (printf "%s.key" $TLD) }};
+
+	root /var/www/default/htdocs;
+    error_page 404 /index.html;
+}
+
+{{ else }}
+
 server {
   listen 80 default_server;
   server_name _;
   root /var/www/default/htdocs;
   error_page 404 /index.html;
 }
+
+{{end}}
 
 {{ define "server" }}
 


### PR DESCRIPTION
When we switched over to https for local development, we noticed that requests for unknown subdomains would occasionally get redirected to random applications or to a plain "not found" page. This PR will redirect these requests to the index.html if a wildcard certificate for the specified top level domain is available, mirroring the functionality for http requests for unknown subdomains. 