### PR TITLE
Update go version to rebuild for M1/arm support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM golang:1.15 as builder
+FROM golang:1.16 as builder
 WORKDIR /go/src/github.com/codekitchen/dinghy-http-proxy
 COPY join-networks.go .
+COPY go.mod .
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go get -v github.com/fsouza/go-dockerclient
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -v -o join-networks
 
@@ -8,13 +9,13 @@ FROM jwilder/nginx-proxy:alpine
 LABEL Author="Brian Palmer <brian@codekitchen.net>"
 
 RUN apk upgrade --no-cache \
- && apk add --no-cache --virtual=run-deps \
-      su-exec \
-      curl \
-      dnsmasq \
- && rm -rf /tmp/* \
-      /var/cache/apk/* \
-      /var/tmp/*
+     && apk add --no-cache --virtual=run-deps \
+     su-exec \
+     curl \
+     dnsmasq \
+     && rm -rf /tmp/* \
+     /var/cache/apk/* \
+     /var/tmp/*
 
 COPY --from=builder /go/src/github.com/codekitchen/dinghy-http-proxy/join-networks /app/join-networks
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/codekitchen/dinghy-http-proxy
+
+go 1.16
+
+require (
+    github.com/fsouza/go-dockerclient v1.7.4
+)


### PR DESCRIPTION
I built a new version of this container because I was getting an error from go on my M1 (same as this one: https://github.com/FreedomBen/dory/issues/49#issuecomment-823991634). I looked at the `nginx-proxy` repo and they seemed to have ARM support. So I figured just a rebuild with docker would do it. To get it building against `github.com/fsouza/go-dockerclient` I needed to update `golang` to `1.16` and include a `go.mod` file. Those are the changes in this PR.

I hadn't build a multiplatform container before so I also [followed these instructions](https://www.docker.com/blog/multi-arch-images/) for that. You can see the resulting container at [`taybenlor/dinghy-http-proxy:latest`](https://hub.docker.com/repository/docker/taybenlor/dinghy-http-proxy).

This seems to work for me as part of Dory but I don't use Dinghy.

